### PR TITLE
NPE when adding device for Sonoff Mini & Tasmota 7.0.0.4

### DIFF
--- a/devicetypes/brettsheleski/tasmota.src/tasmota.groovy
+++ b/devicetypes/brettsheleski/tasmota.src/tasmota.groovy
@@ -134,11 +134,9 @@ def spawnChildDevices(){
         log.debug "GPIO: ${state.gpio}"
         log.debug "Module: ${state.module}"
         
-        def moduleId = state.module.split()[0].toInteger();
-        
+        def moduleId = state.module.keySet()[0].toInteger();
+	    
         def devices = getModuleDevices(moduleId) << getGpioDevices(state.gpio);
-
-        
 
         def existingDevices = getChildDevices();
         def deviceConfig = null;
@@ -308,10 +306,7 @@ def getGpioDevices(gpios){
             continue;
         }
 
-		startIndex = e.value.indexOf('(', 0) + 1;
-		endIndex = e.value.indexOf(')', startIndex);
-
-        switch(e.value.substring(startIndex, endIndex).toLowerCase()){
+	switch(e.value.values()[0].toLowerCase()){
 
 			case "relay1":
 			case "relay1i":


### PR DESCRIPTION
New to Tasmoto so this might be a fix for a problem caused because of my lack of understanding, but like some others, I was getting this
 error java.lang.NullPointerException @line 137 (spawnChildDevices) for the Sonoff Mini with Tasmota 7.0.0.4 by Theo Arends installed.
I'm a groovy novice, but I suspect that these changes are necessary because Tasmota has changed some  of it's responses.
I only have Tasmota on Sonoff Mini's but this appears to work for me.
https://community.smartthings.com/t/integrating-sonoff-mini-with-st-my-findings/173053/6 (not my post)