### PR TITLE
Add support for power metering and switch updates

### DIFF
--- a/devicetypes/brettsheleski/tasmota-energy.src/readme.md
+++ b/devicetypes/brettsheleski/tasmota-energy.src/readme.md
@@ -1,0 +1,13 @@
+# Tasmota-base
+This is a device handler to be used as a child device handlers for the [Tasmota](https://github.com/BrettSheleski/SmartThingsPublic/tree/master/devicetypes/brettsheleski/tasmota.src) device handler.
+
+It is used by the following energy metering-enabled Tasmota-compatible devices:
+ - Sonoff Pow
+ - Sonoff Pow R2
+ - Blitzwolf SHP
+ - FrankEver FLHS-ZN04
+ - Gosung SP1
+ - Shelly 1PM
+ - Shelly 2
+ - Shelly 2.5
+ - Shelly Plug S

--- a/devicetypes/brettsheleski/tasmota-energy.src/tasmota-energy.groovy
+++ b/devicetypes/brettsheleski/tasmota-energy.src/tasmota-energy.groovy
@@ -1,0 +1,123 @@
+metadata {
+	definition(name: "Tasmota-Energy", namespace: "BrettSheleski", author: "Brett Sheleski", ocfDeviceType: "oic.d.smartplug", mnmn: "SmartThings", vid: "generic-switch-power-energy") {
+		capability "Switch"
+        	capability "Energy Meter"
+        	capability "Power Meter"
+	}
+
+	// UI tile definitions
+	tiles(scale: 2) {
+		multiAttributeTile(name:"switch", type: "generic", width: 6, height: 4, canChangeIcon: true){
+			tileAttribute ("device.switch", key: "PRIMARY_CONTROL") {
+				attributeState "on", label: '${name}', action: "momentary.push", icon: "st.switches.switch.on", backgroundColor: "#79b821"
+				attributeState "off", label: '${name}', action: "momentary.push", icon: "st.switches.switch.off", backgroundColor: "#ffffff"
+			}
+		}
+
+		valueTile("power", "device.power", decoration: "flat", width: 2, height: 2) {
+			state "default", label:'${currentValue} W'
+		}
+
+		valueTile("energy", "device.energy", decoration: "flat", width: 2, height: 2) {
+			state "default", label:'${currentValue} kWh'
+		}
+
+		valueTile("powerChannel", "powerChannel", width: 6, height: 1) {
+			state "powerChannel", label: 'Channel ${currentValue}', backgroundColor: "#ffffff"
+		}
+
+		valueTile("gpio", "gpio", width: 6, height: 1) {
+			state "gpio", label: 'GPIO ${gpio}', backgroundColor: "#ffffff"
+		}
+
+		main "switch"
+		details(["switch", "power", "energy", "powerChannel", "gpio"])
+	}
+
+	preferences {
+		section("Main") {
+            input(name: "powerChannel", type: "number", title: "Power Channel", description: "", displayDuringSetup: true, required: true)
+			input(name: "gpio", type: "number", title: "GPIO", description: "", displayDuringSetup: false, required: false)
+		}
+	}
+}
+
+def initializeChild(Map options){
+	log.debug "OPTIONS: $options"
+
+	sendEvent(name : "powerChannel", value: options["powerChannel"]);
+	sendEvent(name : "gpio", value: options["gpio"]);
+}
+
+def on(){
+    setPower("on")
+}
+
+def off(){
+    setPower("off")
+}
+
+def push(){
+    setPower("toggle")
+}
+
+def setPower(power){
+	log.debug "Setting power to: $power"
+
+	def channel = device.latestValue("powerChannel")
+	def commandName = "Power$channel";
+	def payload = power;
+
+	log.debug "COMMAND: $commandName ($payload)"
+
+	def command = parent.createCommand(commandName, payload, "setPowerCallback");;
+
+    sendHubCommand(command);
+}
+
+def setPowerCallback(physicalgraph.device.HubResponse response){
+	
+	def channel = device.latestValue("powerChannel")
+	
+	log.debug "Finished Setting power (channel: $channel), JSON: ${response.json}"
+
+    def on = response.json."POWER${channel}" == "ON";
+
+	if ("$channel" == "1"){
+		// if this is channel 1, there may not be any other channels.
+		// In this case the property of the JSON response is just POWER (not POWER1)
+		on = on || response.json.POWER == "ON";
+	}
+
+    setSwitchState(on);
+}
+
+def updateStatus(status){
+
+	// Device power status(es) are reported back by the Status.Power property
+	// The Status.Power property contains the on/off state of all channels (in case of a Sonoff 4CH or Sonoff Dual)
+	// This is binary-encoded where each bit represents the on/off state of a particular channel
+	// EG: 7 in binary is 0111.  In this case channels 1, 2, and 3 are ON and channel 4 is OFF
+
+	def powerMask = 0b0001;
+
+	def powerChannel = device.latestValue("powerChannel");
+
+	powerMask = powerMask << ("$powerChannel".toInteger() - 1); // shift the bits over 
+
+	def on = (powerMask & status.Status.Power);
+
+	setSwitchState(on);
+ 
+ 	def energy = status?.StatusSNS?.ENERGY;
+	if (energy) {
+		sendEvent(name: "power", value: energy.get("Power", 0), unit: "W");
+		sendEvent(name: "energy", value: energy.get("Total", 0.0), unit: "kWh");
+	}
+}
+
+def setSwitchState(on){
+	log.debug "Setting switch to ${on ? 'ON' : 'OFF'}"
+
+	sendEvent(name: "switch", value: on ? "on" : "off")
+}

--- a/devicetypes/brettsheleski/tasmota-power.src/readme.md
+++ b/devicetypes/brettsheleski/tasmota-power.src/readme.md
@@ -6,7 +6,6 @@ It is used by the following Tasmota-compatible devices:
  - Sonoff RF
  - Sonoff SV
  - Sonoff TH
- - Sonoff POW
  - Sonoff S20 Socket
  - Sonoff Slampher
  - Sonoff Touch

--- a/devicetypes/brettsheleski/tasmota-power.src/tasmota-power.groovy
+++ b/devicetypes/brettsheleski/tasmota-power.src/tasmota-power.groovy
@@ -1,8 +1,7 @@
 metadata {
 	definition(name: "Tasmota-Power", namespace: "BrettSheleski", author: "Brett Sheleski", ocfDeviceType: "oic.d.smartplug") {
+		capability "Momentary"
 		capability "Switch"
-        	capability "Energy Meter"
-        	capability "Power Meter"
 	}
 
 	// UI tile definitions
@@ -14,14 +13,6 @@ metadata {
 			}
 		}
 
-		valueTile("power", "device.power", decoration: "flat", width: 2, height: 2) {
-			state "default", label:'${currentValue} W'
-		}
-
-		valueTile("energy", "device.energy", decoration: "flat", width: 2, height: 2) {
-			state "default", label:'${currentValue} kWh'
-		}
-
 		valueTile("powerChannel", "powerChannel", width: 6, height: 1) {
 			state "powerChannel", label: 'Channel ${currentValue}', backgroundColor: "#ffffff"
 		}
@@ -31,7 +22,7 @@ metadata {
 		}
 
 		main "switch"
-		details(["switch", "power", "energy", "powerChannel", "gpio"])
+		details(["switch", "powerChannel", "gpio"])
 	}
 
 	preferences {
@@ -108,12 +99,6 @@ def updateStatus(status){
 	def on = (powerMask & status.Status.Power);
 
 	setSwitchState(on);
- 
- 	def energy = status?.StatusSNS?.ENERGY;
-	if (energy) {
-		sendEvent(name: "power", value: energy.get("Power", 0), unit: "W");
-		sendEvent(name: "energy", value: energy.get("Total", 0.0), unit: "kWh");
-	}
 }
 
 def setSwitchState(on){

--- a/devicetypes/brettsheleski/tasmota-power.src/tasmota-power.groovy
+++ b/devicetypes/brettsheleski/tasmota-power.src/tasmota-power.groovy
@@ -1,7 +1,8 @@
 metadata {
 	definition(name: "Tasmota-Power", namespace: "BrettSheleski", author: "Brett Sheleski", ocfDeviceType: "oic.d.smartplug") {
-		capability "Momentary"
 		capability "Switch"
+        	capability "Energy Meter"
+        	capability "Power Meter"
 	}
 
 	// UI tile definitions
@@ -13,6 +14,14 @@ metadata {
 			}
 		}
 
+		valueTile("power", "device.power", decoration: "flat", width: 2, height: 2) {
+			state "default", label:'${currentValue} W'
+		}
+
+		valueTile("energy", "device.energy", decoration: "flat", width: 2, height: 2) {
+			state "default", label:'${currentValue} kWh'
+		}
+
 		valueTile("powerChannel", "powerChannel", width: 6, height: 1) {
 			state "powerChannel", label: 'Channel ${currentValue}', backgroundColor: "#ffffff"
 		}
@@ -22,7 +31,7 @@ metadata {
 		}
 
 		main "switch"
-		details(["switch", "powerChannel", "gpio"])
+		details(["switch", "power", "energy", "powerChannel", "gpio"])
 	}
 
 	preferences {
@@ -99,6 +108,12 @@ def updateStatus(status){
 	def on = (powerMask & status.Status.Power);
 
 	setSwitchState(on);
+ 
+ 	def energy = status?.StatusSNS?.ENERGY;
+	if (energy) {
+		sendEvent(name: "power", value: energy.get("Power", 0), unit: "W");
+		sendEvent(name: "energy", value: energy.get("Total", 0.0), unit: "kWh");
+	}
 }
 
 def setSwitchState(on){

--- a/devicetypes/brettsheleski/tasmota.src/tasmota.groovy
+++ b/devicetypes/brettsheleski/tasmota.src/tasmota.groovy
@@ -211,7 +211,6 @@ def getModuleDevices(moduleId){
         case 2: // Sonoff RF
         case 3: // Sonoff SV
         case 4: // Sonoff TH
-        case 6: // Sonoff Pow
         case 8: // S20 Socket
         case 9: // Slampher
         case 10: // Sonoff Touch
@@ -265,8 +264,13 @@ def getModuleDevices(moduleId){
             devices[parentId + '-Fan'] = [namespace : "BrettSheleski", type: "Tasmota-Fan", label : "${thisLabel} Fan Speed", options : []]
             break;
 	    
+        case 6: // Sonoff Pow
+        case 24: // Huafan SS
+        case 43: // Sonoff Pow 2
 	case 45: // Blitzwolf SHP2
-            devices[parentId + '-Power'] = [namespace : "BrettSheleski", type: "Tasmota-Power", label : "${thisLabel} Switch", options : [powerChannel : 1]];
+	case 47: // Shelly 2
+	case 55: // Gosung SP1
+            devices[parentId + '-Energy'] = [namespace : "BrettSheleski", type: "Tasmota-Energy", label : "${thisLabel} Switch", options : [powerChannel : 1]];
             break;
 
         case 14: // Motor C/AC
@@ -274,7 +278,6 @@ def getModuleDevices(moduleId){
         case 16: // EXS Relay
         case 17: // WiOn
         case 20: // H801
-        case 24: // Huafan SS
         case 27: // AiLight
         case 31: // Supla Espablo
         case 32: // Witty Cloud

--- a/devicetypes/brettsheleski/tasmota.src/tasmota.groovy
+++ b/devicetypes/brettsheleski/tasmota.src/tasmota.groovy
@@ -107,6 +107,12 @@ def updated(){
     reload();
 }
 
+def initialize() {
+    unschedule(updateStatus)
+    runEvery1Minute(updateStatus)
+    sendEvent(name: "checkInterval", value: 120, data: [protocol: "lan", hubHardwareId: device.hub.hardwareID], displayed: false)
+}
+
 def reload(){
     state.module = null;
     state.gpio = null;
@@ -114,7 +120,7 @@ def reload(){
     sendCommand("module", null, getModuleCompleted);
     sendCommand("gpio", null, getGpioCompleted);
 
-    refresh();
+    initialize();
 }
 
 def getModuleCompleted(physicalgraph.device.HubResponse response){


### PR DESCRIPTION
Add tiles and capabilities similar to e.g. "Zigbee Metering Plug", for Power Meter and Energy Meter.
Also made it auto-refresh every minute - this is applicable also for non power metering switches, as at the moment a manual switch would go unnoticed.